### PR TITLE
use `-undefined dynamic_lookup` option for Darwin

### DIFF
--- a/runtests.bash
+++ b/runtests.bash
@@ -3,13 +3,18 @@
 set -x
 set -v
 
+OS=`uname -s`
 #Remove .so
 find . -name *.so | xargs rm
 
 #For plugin test, compile Percolator plugin
 cd plugins/percolator;
 gcc -c percolator.c -Wall -Werror -fPIC -o percolator.o
-gcc -shared -o libctrpercolator.so percolator.o -undefined dynamic_lookup
+LDFLAGS='-shared'
+if [ $OS = "Darwin" ]; then
+  LDFLAGS='-shared -undefined dynamic_lookup'
+fi
+gcc ${LDFLAGS} -o libctrpercolator.so percolator.o
 cd ..
 cd ..
 cp plugins/percolator/libctrpercolator.so mods/percolator/libctrpercolator.so
@@ -20,7 +25,7 @@ gcc -c ccgi.c -Wall	-Werror -fpic -o ccgi.o
 gcc -c prefork.c -Wall -Werror -fpic -o prefork.o
 cd ..
 gcc -c request.c -Wall -Werror -fpic -o request.o
-gcc -shared -o libctrrequest.so request.o ccgi-1.2/ccgi.o ccgi-1.2/prefork.o
+gcc ${LDFLAGS} -o libctrrequest.so request.o ccgi-1.2/ccgi.o ccgi-1.2/prefork.o
 cd ..
 cd ..
 cp plugins/request/libctrrequest.so mods/request/libctrrequest.so

--- a/runtests.bash
+++ b/runtests.bash
@@ -8,7 +8,8 @@ find . -name *.so | xargs rm
 
 #For plugin test, compile Percolator plugin
 cd plugins/percolator;
-gcc -c percolator.c -Wall -Werror -fpic -o percolator.o ; gcc -shared -o libctrpercolator.so percolator.o
+gcc -c percolator.c -Wall -Werror -fPIC -o percolator.o
+gcc -shared -o libctrpercolator.so percolator.o -undefined dynamic_lookup
 cd ..
 cd ..
 cp plugins/percolator/libctrpercolator.so mods/percolator/libctrpercolator.so
@@ -18,7 +19,8 @@ cd plugins/request/ccgi-1.2;
 gcc -c ccgi.c -Wall	-Werror -fpic -o ccgi.o
 gcc -c prefork.c -Wall -Werror -fpic -o prefork.o
 cd ..
-gcc -c request.c -Wall -Werror -fpic -o request.o ; gcc -shared -o libctrrequest.so request.o ccgi-1.2/ccgi.o ccgi-1.2/prefork.o
+gcc -c request.c -Wall -Werror -fpic -o request.o
+gcc -shared -o libctrrequest.so request.o ccgi-1.2/ccgi.o ccgi-1.2/prefork.o
 cd ..
 cd ..
 cp plugins/request/libctrrequest.so mods/request/libctrrequest.so

--- a/runtests.bash
+++ b/runtests.bash
@@ -21,10 +21,10 @@ cp plugins/percolator/libctrpercolator.so mods/percolator/libctrpercolator.so
 
 #request test
 cd plugins/request/ccgi-1.2;
-gcc -c ccgi.c -Wall	-Werror -fpic -o ccgi.o
-gcc -c prefork.c -Wall -Werror -fpic -o prefork.o
+gcc -c ccgi.c -Wall	-Werror -fPIC -o ccgi.o
+gcc -c prefork.c -Wall -Werror -fPIC -o prefork.o
 cd ..
-gcc -c request.c -Wall -Werror -fpic -o request.o
+gcc -c request.c -Wall -Werror -fPIC -o request.o
 gcc ${LDFLAGS} -o libctrrequest.so request.o ccgi-1.2/ccgi.o ccgi-1.2/prefork.o
 cd ..
 cd ..

--- a/runtests.bash
+++ b/runtests.bash
@@ -4,16 +4,16 @@ set -x
 set -v
 
 OS=`uname -s`
+LDFLAGS='-shared'
+if [ $OS = "Darwin" ]; then
+  LDFLAGS='-shared -undefined dynamic_lookup'
+fi
 #Remove .so
 find . -name *.so | xargs rm
 
 #For plugin test, compile Percolator plugin
 cd plugins/percolator;
 gcc -c percolator.c -Wall -Werror -fPIC -o percolator.o
-LDFLAGS='-shared'
-if [ $OS = "Darwin" ]; then
-  LDFLAGS='-shared -undefined dynamic_lookup'
-fi
 gcc ${LDFLAGS} -o libctrpercolator.so percolator.o
 cd ..
 cd ..


### PR DESCRIPTION
fix an error in generating shared object

```
+ gcc -shared -o libctrpercolator.so percolator.o
Undefined symbols for architecture x86_64:
  "_ctr_build_number_from_float", referenced from:
      _ctr_percolator_new in percolator.o
  "_ctr_build_string", referenced from:
      _ctr_percolator_brew in percolator.o
      _ctr_percolator_add_coffee_water in percolator.o
      _ctr_percolator_new in percolator.o
      _begin in percolator.o
  "_ctr_internal_cast2number", referenced from:
      _ctr_percolator_add_coffee_water in percolator.o
  "_ctr_internal_create_func", referenced from:
      _begin in percolator.o
  "_ctr_internal_create_object", referenced from:
      _ctr_percolator_new in percolator.o
  "_ctr_internal_object_add_property", referenced from:
      _begin in percolator.o
  "_ctr_internal_object_find_property", referenced from:
      _ctr_percolator_brew in percolator.o
  "_ctr_internal_object_set_property", referenced from:
      _ctr_percolator_brew in percolator.o
      _ctr_percolator_add_coffee_water in percolator.o
      _ctr_percolator_new in percolator.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

but I got another error...

```
% ./ctr tests/test0117.ctr
Let's make a nice cup of coffee!
[1]    59021 segmentation fault  ./ctr tests/test0117.ctr
```
